### PR TITLE
Log only if entity is present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.isopropylcyanide</groupId>
     <artifactId>jersey-log-utils</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
     <name>Log Filter Utils</name>
     <description>A set of helpful utilities for the conventional log filters</description>
     <url>https://github.com/isopropylcyanide/jersey-log-utils</url>

--- a/src/main/java/com/github/isopropylcyanide/jerseylogutils/DelayedRequestResponseLoggingFilter.java
+++ b/src/main/java/com/github/isopropylcyanide/jerseylogutils/DelayedRequestResponseLoggingFilter.java
@@ -92,7 +92,10 @@ public class DelayedRequestResponseLoggingFilter implements ContainerRequestFilt
                 if (requestResponseBuilder != null) {
                     log(requestLogBuilder);
                     StringBuilder responseBuilder = requestResponseBuilder.buildResponseLog(requestContext, responseContext);
-                    log(responseBuilder);
+                    if (!responseContext.hasEntity()) {
+                        //if entity is present, it will be called by the server run time through the interceptor
+                        log(responseBuilder);
+                    }
                 }
             }
         } finally {


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Minor Fix | Low |

This PR includes the following
- Prevents double logging of response entity + response entity stream
- Adds test to ensure response is explicitly logged only when there's an entity 
- Bumps up the version to 1.1
- Tested through a sample application that response is logged once when entity is present
- Tested through a sample application that response is logged once when entity is not present

## Motivation
- Previously, we were logging entity (stream + body) + stream. Double logging of stream results in a duplicate log
- Glassfish runtime automatically calls the `WriterInterceptor` if response context has an entity

## Maven 
This project is available on Maven Central. To add it to your project you can add the following dependency to your
`pom.xml`:

```xml
    <dependency>
        <groupId>com.github.isopropylcyanide</groupId>
        <artifactId>jersey-log-utils/artifactId>
        <version>1.1</version>
     </dependency>
```

