### PR TITLE
Integrate Client Whitelisted Logger + Support for Contexts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.isopropylcyanide</groupId>
     <artifactId>jersey-log-utils</artifactId>
-    <version>1.1</version>
+    <version>1.2-SNAPSHOT</version>
     <name>Log Filter Utils</name>
     <description>A set of helpful utilities for the conventional log filters</description>
     <url>https://github.com/isopropylcyanide/jersey-log-utils</url>

--- a/src/main/java/com/github/isopropylcyanide/jerseylogutils/DelayedServerRequestResponseLoggingFilter.java
+++ b/src/main/java/com/github/isopropylcyanide/jerseylogutils/DelayedServerRequestResponseLoggingFilter.java
@@ -52,28 +52,28 @@ import static com.github.isopropylcyanide.jerseylogutils.builder.RequestResponse
  * Note that the {{@link #filter(ContainerRequestContext, ContainerResponseContext)}} block for response
  * is always run, and so the thread local is guaranteed to be garbage collected without leaks.
  */
-public class DelayedRequestResponseLoggingFilter implements ContainerRequestFilter, ContainerResponseFilter, WriterInterceptor {
+public class DelayedServerRequestResponseLoggingFilter implements ContainerRequestFilter, ContainerResponseFilter, WriterInterceptor {
 
     private final RequestResponseBuilder requestResponseBuilder;
     private final ResponseCondition responseCondition;
     private final ThreadLocal<StringBuilder> requestLogCache = new ThreadLocal<>();
     private final Logger logger;
 
-    public DelayedRequestResponseLoggingFilter(ResponseCondition responseCondition, int maxEntitySize) {
-        this.requestResponseBuilder = new RequestResponseBuilder(Math.max(0, maxEntitySize), DelayedRequestResponseLoggingFilter.class.getName());
+    public DelayedServerRequestResponseLoggingFilter(ResponseCondition responseCondition, int maxEntitySize) {
+        this.requestResponseBuilder = new RequestResponseBuilder(Math.max(0, maxEntitySize), DelayedServerRequestResponseLoggingFilter.class.getName());
         this.responseCondition = responseCondition;
-        this.logger = Logger.getLogger(DelayedRequestResponseLoggingFilter.class.getName());
+        this.logger = Logger.getLogger(DelayedServerRequestResponseLoggingFilter.class.getName());
     }
 
-    public DelayedRequestResponseLoggingFilter(Logger logger, ResponseCondition responseCondition) {
+    public DelayedServerRequestResponseLoggingFilter(Logger logger, ResponseCondition responseCondition) {
         this.responseCondition = responseCondition;
-        this.requestResponseBuilder = new RequestResponseBuilder(DEFAULT_MAX_ENTITY_SIZE, DelayedRequestResponseLoggingFilter.class.getName());
+        this.requestResponseBuilder = new RequestResponseBuilder(DEFAULT_MAX_ENTITY_SIZE, DelayedServerRequestResponseLoggingFilter.class.getName());
         this.logger = logger;
     }
 
-    public DelayedRequestResponseLoggingFilter(Logger logger, ResponseCondition responseCondition, int maxEntitySize) {
+    public DelayedServerRequestResponseLoggingFilter(Logger logger, ResponseCondition responseCondition, int maxEntitySize) {
         this.responseCondition = responseCondition;
-        this.requestResponseBuilder = new RequestResponseBuilder(Math.max(0, maxEntitySize), DelayedRequestResponseLoggingFilter.class.getName());
+        this.requestResponseBuilder = new RequestResponseBuilder(Math.max(0, maxEntitySize), DelayedServerRequestResponseLoggingFilter.class.getName());
         this.logger = logger;
     }
 

--- a/src/main/java/com/github/isopropylcyanide/jerseylogutils/WhitelistedClientLoggingFilter.java
+++ b/src/main/java/com/github/isopropylcyanide/jerseylogutils/WhitelistedClientLoggingFilter.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.isopropylcyanide.jerseylogutils;
+
+import com.github.isopropylcyanide.jerseylogutils.builder.RequestResponseBuilder;
+import com.github.isopropylcyanide.jerseylogutils.model.URIContext;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.ext.WriterInterceptor;
+import javax.ws.rs.ext.WriterInterceptorContext;
+import java.io.IOException;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static com.github.isopropylcyanide.jerseylogutils.builder.RequestResponseBuilder.DEFAULT_MAX_ENTITY_SIZE;
+
+
+/**
+ * This logging filter helps exclude logging client requests and responses for URIs that match a set of excluded URIs
+ */
+public class WhitelistedClientLoggingFilter implements ClientRequestFilter, ClientResponseFilter, WriterInterceptor {
+
+    private final RequestResponseBuilder requestResponseBuilder;
+    private final Logger logger;
+
+    /**
+     * A set of exclude contexts for which the client request and response logging will not be performed
+     * if the URI/Method pair matches any of the path in the set of blacklisted paths.
+     */
+    private final Set<URIContext> excludeContexts;
+
+    public WhitelistedClientLoggingFilter(Set<URIContext> excludeContexts) {
+        this.excludeContexts = excludeContexts;
+        this.logger = Logger.getLogger(WhitelistedClientLoggingFilter.class.getName());
+        this.requestResponseBuilder = new RequestResponseBuilder(DEFAULT_MAX_ENTITY_SIZE, WhitelistedClientLoggingFilter.class.getName());
+    }
+
+    public WhitelistedClientLoggingFilter(Set<URIContext> excludeContexts, int maxEntitySize) {
+        this.excludeContexts = excludeContexts;
+        this.logger = Logger.getLogger(WhitelistedClientLoggingFilter.class.getName());
+        this.requestResponseBuilder = new RequestResponseBuilder(Math.max(0, maxEntitySize), WhitelistedClientLoggingFilter.class.getName());
+    }
+
+    public WhitelistedClientLoggingFilter(Set<URIContext> excludeContexts, Logger logger, int maxEntitySize) {
+        this.excludeContexts = excludeContexts;
+        this.logger = logger;
+        this.requestResponseBuilder = new RequestResponseBuilder(maxEntitySize, WhitelistedClientLoggingFilter.class.getName());
+    }
+
+    public WhitelistedClientLoggingFilter(Set<URIContext> excludeContexts, Logger logger) {
+        this.excludeContexts = excludeContexts;
+        this.logger = logger;
+        this.requestResponseBuilder = new RequestResponseBuilder(DEFAULT_MAX_ENTITY_SIZE, WhitelistedClientLoggingFilter.class.getName());
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        String path = requestContext.getUri().getPath();
+        String httpMethod = requestContext.getMethod();
+
+        if (isWhiteListed(path, httpMethod, excludeContexts)) {
+            StringBuilder requestLog = requestResponseBuilder.buildRequestLog(requestContext);
+            if (!requestContext.hasEntity()) {
+                //if entity is present, it will be called by the client run time through the interceptor
+                log(requestLog);
+            }
+        }
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
+        String path = requestContext.getUri().getPath();
+        String httpMethod = requestContext.getMethod();
+
+        if (isWhiteListed(path, httpMethod, excludeContexts)) {
+            StringBuilder responseLog = requestResponseBuilder.buildResponseLog(requestContext, responseContext);
+            log(responseLog);
+        }
+    }
+
+    @Override
+    public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+        log(requestResponseBuilder.getEntityWriterBuilder(context));
+    }
+
+    private boolean isWhiteListed(String path, String httpMethod, Set<URIContext> URIContexts) {
+        for (URIContext context : URIContexts) {
+            if (path.contains(context.getPath())) {
+                if (context.getHttpMethod() != null) {
+                    return !context.getHttpMethod().equalsIgnoreCase(httpMethod);
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void log(StringBuilder b) {
+        if (logger != null && b != null) {
+            String msg = b.toString();
+            logger.info(msg);
+        }
+    }
+
+}

--- a/src/main/java/com/github/isopropylcyanide/jerseylogutils/model/URIContext.java
+++ b/src/main/java/com/github/isopropylcyanide/jerseylogutils/model/URIContext.java
@@ -1,0 +1,43 @@
+package com.github.isopropylcyanide.jerseylogutils.model;
+
+public class URIContext {
+
+    private final String httpMethod;
+    private final String path;
+
+    public URIContext(String httpMethod, String path) {
+        this.httpMethod = httpMethod;
+        this.path = path;
+    }
+
+    public URIContext(String path) {
+        this.path = path;
+        this.httpMethod = null;
+    }
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
+    public String toString() {
+        return "ExcludeContext{" +
+                "httpMethod='" + (httpMethod != null ? httpMethod : "*") + '\'' +
+                ", path='" + path + '\'' +
+                '}';
+    }
+}

--- a/src/test/java/com/github/isopropylcyanide/jerseylogutils/DelayedServerRequestResponseLoggingFilterTest.java
+++ b/src/test/java/com/github/isopropylcyanide/jerseylogutils/DelayedServerRequestResponseLoggingFilterTest.java
@@ -1,6 +1,6 @@
 package com.github.isopropylcyanide.jerseylogutils;
 
-import com.github.isopropylcyanide.jerseylogutils.DelayedRequestResponseLoggingFilter.ResponseCondition;
+import com.github.isopropylcyanide.jerseylogutils.DelayedServerRequestResponseLoggingFilter.ResponseCondition;
 import org.glassfish.jersey.internal.PropertiesDelegate;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
@@ -27,9 +27,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class DelayedRequestResponseLoggingFilterTest {
+public class DelayedServerRequestResponseLoggingFilterTest {
 
-    private DelayedRequestResponseLoggingFilter loggingFilter;
+    private DelayedServerRequestResponseLoggingFilter loggingFilter;
 
     @Mock
     private Logger logger;
@@ -41,7 +41,7 @@ public class DelayedRequestResponseLoggingFilterTest {
 
     @Test
     public void testFilterContainerRequestContextAddsValueInThreadLocalCache() throws URISyntaxException, IOException {
-        loggingFilter = new DelayedRequestResponseLoggingFilter(ResponseCondition.ON_RESPONSE_2XX, 100);
+        loggingFilter = new DelayedServerRequestResponseLoggingFilter(ResponseCondition.ON_RESPONSE_2XX, 100);
         ContainerRequest request = stubContainerRequest();
         loggingFilter.filter(request);
 
@@ -51,7 +51,7 @@ public class DelayedRequestResponseLoggingFilterTest {
 
     @Test
     public void testFilterContainerResponseLogsRequestAndResponseWhenResponseConditionIsMet() throws URISyntaxException, IOException {
-        loggingFilter = new DelayedRequestResponseLoggingFilter(logger, ResponseCondition.ON_RESPONSE_4XX_5XX, 100);
+        loggingFilter = new DelayedServerRequestResponseLoggingFilter(logger, ResponseCondition.ON_RESPONSE_4XX_5XX, 100);
         ContainerRequest request = stubContainerRequest();
         request.setEntityStream(new ByteArrayInputStream("{Request entity}".getBytes()));
 
@@ -76,7 +76,7 @@ public class DelayedRequestResponseLoggingFilterTest {
 
     @Test
     public void testFilterContainerResponseLogsRequestButNotResponseWhenConditionIsMetAndResponseHasEntity() throws URISyntaxException, IOException {
-        loggingFilter = new DelayedRequestResponseLoggingFilter(logger, ResponseCondition.ON_RESPONSE_4XX_5XX, 100);
+        loggingFilter = new DelayedServerRequestResponseLoggingFilter(logger, ResponseCondition.ON_RESPONSE_4XX_5XX, 100);
         ContainerRequest request = stubContainerRequest();
         request.setEntityStream(new ByteArrayInputStream("{Request entity}".getBytes()));
 
@@ -97,7 +97,7 @@ public class DelayedRequestResponseLoggingFilterTest {
 
     @Test
     public void testFilterContainerResponseDoesntLogRequestAndResponseWhenResponseConditionIsNotMetButCacheIsCleared() throws URISyntaxException, IOException {
-        loggingFilter = new DelayedRequestResponseLoggingFilter(logger, ResponseCondition.ON_RESPONSE_5XX, 100);
+        loggingFilter = new DelayedServerRequestResponseLoggingFilter(logger, ResponseCondition.ON_RESPONSE_5XX, 100);
         ContainerRequest request = stubContainerRequest();
 
         Response response200 = Response.status(200).build();
@@ -111,7 +111,7 @@ public class DelayedRequestResponseLoggingFilterTest {
 
     @Test
     public void testFilterContainerResponseDoesntLogRequestAndResponseWhenResponseConditionIsNotMetForConflictButCacheIsCleared() throws URISyntaxException, IOException {
-        loggingFilter = new DelayedRequestResponseLoggingFilter(logger, ResponseCondition.ON_RESPONSE_4XX_5XX_NON_CONFLICT, 100);
+        loggingFilter = new DelayedServerRequestResponseLoggingFilter(logger, ResponseCondition.ON_RESPONSE_4XX_5XX_NON_CONFLICT, 100);
         ContainerRequest request = stubContainerRequest();
 
         Response response409 = Response.status(409).build();
@@ -125,7 +125,7 @@ public class DelayedRequestResponseLoggingFilterTest {
 
     @Test
     public void testFilterContainerResponseDoesntLogRequestAndResponseWhenResponseConditionIsNotFoundForConflictButCacheIsCleared() throws URISyntaxException, IOException {
-        loggingFilter = new DelayedRequestResponseLoggingFilter(logger, ResponseCondition.ON_RESPONSE_4XX_5XX_NON_NOT_FOUND, 100);
+        loggingFilter = new DelayedServerRequestResponseLoggingFilter(logger, ResponseCondition.ON_RESPONSE_4XX_5XX_NON_NOT_FOUND, 100);
         ContainerRequest request = stubContainerRequest();
 
         Response response409 = Response.status(404).build();

--- a/src/test/java/com/github/isopropylcyanide/jerseylogutils/WhitelistedClientLoggingFilterTest.java
+++ b/src/test/java/com/github/isopropylcyanide/jerseylogutils/WhitelistedClientLoggingFilterTest.java
@@ -1,0 +1,141 @@
+package com.github.isopropylcyanide.jerseylogutils;
+
+import com.github.isopropylcyanide.jerseylogutils.model.URIContext;
+import jersey.repackaged.com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class WhitelistedClientLoggingFilterTest {
+
+    @Mock
+    private Logger logger;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private ClientRequestContext request;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private ClientResponseContext response;
+
+    private WhitelistedClientLoggingFilter loggingFilter;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testFilterDoesNotLogRequestWhenURIMethodPairIsExcluded() throws URISyntaxException {
+        when(request.getUri()).thenReturn(new URI("S3"));
+        when(request.getMethod()).thenReturn(HttpMethod.POST);
+
+        Set<URIContext> contexts = Sets.newHashSet(
+                new URIContext(HttpMethod.GET, "S2"),
+                new URIContext(HttpMethod.POST, "S3")
+        );
+        loggingFilter = new WhitelistedClientLoggingFilter(contexts, logger);
+        loggingFilter.filter(request);
+        verifyZeroInteractions(logger);
+    }
+
+    @Test
+    public void testFilterDoesNotLogRequestWhenURIMethodPairIsExcludedForAnyVerb() throws URISyntaxException {
+        when(request.getUri()).thenReturn(new URI("S3"));
+        when(request.getMethod()).thenReturn(HttpMethod.DELETE);
+
+        Set<URIContext> contexts = Sets.newHashSet(
+                new URIContext(HttpMethod.GET, "S2"),
+                new URIContext("S3")
+        );
+        loggingFilter = new WhitelistedClientLoggingFilter(contexts, logger);
+        loggingFilter.filter(request);
+        verifyZeroInteractions(logger);
+    }
+
+    @Test
+    public void testFilterDoesNotLogRequestWhenEntityIsNotEmpty() throws URISyntaxException {
+        when(request.getUri()).thenReturn(new URI("S3"));
+        when(request.hasEntity()).thenReturn(true);
+        when(request.getMethod()).thenReturn(HttpMethod.GET);
+
+        Set<URIContext> contexts = Sets.newHashSet(
+                new URIContext(HttpMethod.GET, "S1"),
+                new URIContext(HttpMethod.POST, "S2")
+        );
+        loggingFilter = new WhitelistedClientLoggingFilter(contexts, logger, 1000);
+        loggingFilter.filter(request);
+        verifyZeroInteractions(logger);
+    }
+
+    @Test
+    public void testFilterLogsRequestWhenEntityIsEmpty() throws URISyntaxException {
+        Set<URIContext> contexts = Sets.newHashSet(
+                new URIContext(HttpMethod.GET, "S1"),
+                new URIContext(HttpMethod.PUT, "S2")
+        );
+        when(request.getUri()).thenReturn(new URI("S2"));
+        when(request.getMethod()).thenReturn(HttpMethod.POST);
+        when(request.hasEntity()).thenReturn(false);
+
+        loggingFilter = new WhitelistedClientLoggingFilter(contexts, logger, 1000);
+        loggingFilter.filter(request);
+        ArgumentCaptor<String> argCaptor = ArgumentCaptor.forClass(String.class);
+        verify(logger, times(1)).info(argCaptor.capture());
+
+        String requestStream = argCaptor.getAllValues().get(0);
+        assertTrue(requestStream.contains("Sending client request"));
+        assertTrue(requestStream.contains("S2"));
+    }
+
+    @Test
+    public void testFilterDoesNotLogResponseWhenURIIsExcluded() throws URISyntaxException, IOException {
+        when(request.getUri()).thenReturn(new URI("S6"));
+        when(request.getMethod()).thenReturn(HttpMethod.PUT);
+
+        Set<URIContext> contexts = Collections.singleton(
+                new URIContext(HttpMethod.PUT, "S6")
+        );
+        loggingFilter = new WhitelistedClientLoggingFilter(contexts, logger);
+        loggingFilter.filter(request, response);
+        verifyZeroInteractions(logger);
+    }
+
+    @Test
+    public void testFilterLogsResponseWhenEntityIsEmpty() throws URISyntaxException, IOException {
+        when(request.getUri()).thenReturn(new URI("S1"));
+        when(request.getMethod()).thenReturn(HttpMethod.POST);
+        when(response.hasEntity()).thenReturn(false);
+
+        Set<URIContext> contexts = Sets.newHashSet(
+                new URIContext(HttpMethod.GET, "S1"),
+                new URIContext(HttpMethod.PUT, "S2")
+        );
+        loggingFilter = new WhitelistedClientLoggingFilter(contexts, logger);
+        loggingFilter.filter(request, response);
+
+        ArgumentCaptor<String> argCaptor = ArgumentCaptor.forClass(String.class);
+        verify(logger, times(1)).info(argCaptor.capture());
+
+        String requestStream = argCaptor.getAllValues().get(0);
+        assertTrue(requestStream.contains("Client response received"));
+    }
+}


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready | Feature | High |
## Description
- Check in whitelisted client logger
- Refactor existing pieces
- Bump up model version
- Rename `DelayedRequestResponseLoggingFilter` to `DelayedServerRequestResponseLoggingFilter` to account for Delayed Client logger
<!--- Describe your changes in detail -->
## Motivation & Context

We're running out of disk. Logs are churning out pretty quickly. Turns out that the client logger is logging a lot of data.

We've already invested in Server whitelist logger. We need to create a client version.

## How was this tested
- Unit tests in place
- Tested that entities are logged 
- Tested that logs are not duplicate


## Todo
Post merge, release the artifact `1.2.0`

